### PR TITLE
[0.2.0] - Migrate RoxyDialogue to New Input Handler API

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -4,6 +4,44 @@ This document catalogs all **breaking changes** introduced across the Roxy Dialo
 
 ---
 
+## [0.2.0] - 2025-06-11
+
+### Input Handler API Replaced
+
+**What Changed:**
+- Removed deprecated input stack functions `saveAndSetHandler` and `restoreHandler`.
+- Updated `RoxyDialogue:activate()` and `:deactivate()` to use `roxy.Input.addHandler(owner, handler, priority)` and `roxy.Input.removeHandler(owner)`.
+- Optional modal behavior is now handled explicitly using `roxy.Input.makeModalHandler(handler)`.
+
+**Required Updates:**
+If you have custom forks or override `RoxyDialogue`'s input logic:
+
+- **Replace:**
+  ```lua
+  saveAndSetHandler(handler, mask)
+  ...
+  restoreHandler()
+  ```
+
+- **With:**
+
+  ```lua
+  addHandler(self, handler, 100)
+  ...
+  removeHandler(self)
+  ```
+
+- If `self.modal == true`, wrap your handler like this:
+
+  ```lua
+  handler = Input.makeModalHandler(handler)
+  ```
+
+**Reason:**
+This change aligns the plugin with the latest `roxy-engine` core input model, ensuring better control, stack safety, and modular input handling.
+
+---
+
 ## [0.1.1] - 2025-05-29
 
 ### Plugin Initialization Path Changed
@@ -14,7 +52,6 @@ This document catalogs all **breaking changes** introduced across the Roxy Dialo
 - Updated internal loading to use `pcall` for safer initialization with fallback logging via `Log.warn` or `warn`.
 
 **Required Updates:**
-
 - Update your plugin import path:
 
   - **Before:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ---
 
+## [0.2.0] - 2025-06-11
+
+### Changed 🔧
+- Updated `RoxyDialogue` input activation/deactivation logic to use the new priority-based input stack
+- Input handlers now registered with `addHandler(self, handler, 100)` and removed with `removeHandler(self)`
+- Enabled modal behavior using `Input.makeModalHandler(handler)` if `self.modal` is true
+
+### Breaking Changes ⚠️
+- Removed deprecated `saveAndSetHandler` and `restoreHandler` input APIs
+- Plugins or forks overriding `activate()` and `deactivate()` must migrate to:
+  - `Input.addHandler(owner, handler, priority)`
+  - `Input.removeHandler(owner)`
+- For modal dialogues, wrap handlers with `Input.makeModalHandler(handler)`
+- See [BREAKING_CHANGES.md](./BREAKING_CHANGES.md) for full migration steps
+
+---
+
 ## [0.1.1] - 2025-05-29
 
 ### Added ✨

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Add the plugin to your game project using Git submodules:
 
 ```bash
 git submodule add https://github.com/invisiblesloth/roxy-dialogue source/libraries/roxy-dialogue
-```
+````
 
 Build your project:
 
@@ -51,6 +51,44 @@ It relies on Roxy’s:
 - Scene integration (`roxy.Scene`)
 
 It will not work in non-Roxy game projects without modification.
+
+---
+
+## Customization Options
+
+Customize appearance and behavior using `props` when creating a new dialogue:
+
+```lua
+local props = {
+  x = 50,
+  y = 180,
+  width = 240,
+  height = 70,
+  font = yourFont,
+  alignment = Text.ALIGN_LEFT,     -- Text alignment
+  color = Theme.colors.text,
+  background = Theme.colors.panel,
+  cornerRadius = 6,                -- Dialogue box roundness
+  hasBackground = true,            -- Whether to show a background box
+  numberOfLines = 3,               -- Max lines per page
+  leading = 2,                     -- Line spacing
+  paddingHorizontal = 10,
+  paddingVertical = 10,
+  zIndex = 1000,                   -- Sprite layer priority
+  typingSpeed = 90,                -- Characters per second
+  fastMultiplier = 20,             -- Speed boost when fast-advancing
+  fastTypingSpeed = 240,           -- Override fast speed if needed
+  instant = false,                 -- Show full text immediately
+  indicatorX = nil,                -- Override indicator X position
+  indicatorY = nil,                -- Override indicator Y position
+  inputHandler = nil,              -- Custom input handler (optional)
+  modal = true,                    -- If true, wraps handler in makeModalHandler()
+  onDismiss = function() end,      -- Callback when dialogue ends
+  isActive = true                  -- Auto-starts typewriter on init
+}
+```
+
+You can also call `dialogue:startTypewriter()` manually if `isActive` is `false`.
 
 ---
 


### PR DESCRIPTION
### Overview
This release updates `RoxyDialogue` to support the new priority-based input stack system in `roxy-engine`, replacing deprecated handler stack APIs for more robust and modular input control.

### Key Changes
- Migrated to `addHandler`/`removeHandler` for input registration
- Removed use of `saveAndSetHandler` and `restoreHandler`
- Added support for `Input.makeModalHandler()` to enforce modal masking when needed

### Challenges/Notes
- This is a breaking change—custom forks must update `activate()` and `deactivate()` logic accordingly.