### PR TITLE
[0.3.0] - Update Configuration Access for Compatibility with roxy-engine v0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ---
 
+## [0.3.0] - 2025-06-12
+
+### Added ✨
+- Introduced use of `roxy.Configuration.get("key")` to access `defaultTypingSpeed` and `fastTypingMultiplier` values.
+
+### Changed 🔧
+- Replaced legacy `roxy.Configuration.getConfiguration()` calls with scoped `get("key")` accessors.
+- Cached key configuration values locally to simplify typewriter setup and improve clarity.
+
+### Migration Notes 🚚
+- No required changes for plugin consumers.
+- Recommended: When extending `RoxyDialogue`, prefer `roxy.Configuration.get("key")` over accessing the full configuration table.
+
+---
+
 ## [0.2.0] - 2025-06-11
 
 ### Changed 🔧

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ It relies on Roxy’s:
 - Sprite subclassing (`RoxySprite`)
 - Input utilities and update loop
 - Scene integration (`roxy.Scene`)
+- Configuration access (`roxy.Configuration`)
 
 It will not work in non-Roxy game projects without modification.
 

--- a/core/RoxyDialogue.lua
+++ b/core/RoxyDialogue.lua
@@ -36,7 +36,7 @@ local fillRect       <const> = Graphics.fillRect
 local drawTextInRect <const> = Graphics.drawTextInRect
 
 -- Config
-local getConfiguration <const> = roxy.Configuration.getConfiguration
+local getConfigValue <const> = roxy.Configuration.get
 
 -- Asset / cache
 local getIsPoolRegistered <const> = Assets.getIsPoolRegistered
@@ -128,7 +128,8 @@ function RoxyDialogue:init(text, props)
   props = props or {}
   text  = text or ""
 
-  local config = getConfiguration()
+  local defaultTypingSpeed = getConfigValue("defaultTypingSpeed") or DEFAULT_TYPING_SPEED
+  local fastTypingMultiplier = getConfigValue("fastTypingMultiplier") or FAST_TYPING_MULTIPLIER
 
   -- Font
   self.font       = props.font      or Text.font
@@ -213,8 +214,8 @@ function RoxyDialogue:init(text, props)
     self.leading
   )
   self.typewriter = Typewriter(self.pager, {
-    baseSpeed      = props.typingSpeed or config.defaultTypingSpeed or DEFAULT_TYPING_SPEED,
-    fastMultiplier = props.fastMultiplier or config.fastTypingMultiplier or FAST_TYPING_MULTIPLIER,
+    baseSpeed      = props.typingSpeed or defaultTypingSpeed,
+    fastMultiplier = props.fastMultiplier or fastTypingMultiplier,
     fastSpeed      = props.fastTypingSpeed,
     instant        = self.instant,
   })


### PR DESCRIPTION
**Overview**:
This release updates `roxy-dialogue` to align with the configuration API introduced in `roxy-engine` v0.28.0. Configuration values are now retrieved using scoped accessors, improving clarity and future compatibility.

**Key Changes**:
- Replaced `getConfiguration()` with `roxy.Configuration.get("key")`
- Cached `defaultTypingSpeed` and `fastTypingMultiplier` locally
- Improved clarity of typewriter construction logic

**Challenges/Notes**:
No consumer-facing breaking changes were introduced, but developers customizing internal dialogue logic should now use the new `get("key")` accessor format.