### PR TITLE
[0.3.1] - Align RoxyDialogue with Playdate SDK Conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ---
 
+## [0.3.1] - 2025-06-13
+
+### Removed ❌
+- Removed `return RoxyDialogue` from `core/RoxyDialogue.lua`; no longer needed due to Playdate SDK's import handling.
+
+---
+
 ## [0.3.0] - 2025-06-12
 
 ### Added ✨

--- a/core/RoxyDialogue.lua
+++ b/core/RoxyDialogue.lua
@@ -455,5 +455,3 @@ function RoxyDialogue:draw()
   local image = self.typewriter:isComplete() and self._finishedImage or self._typingBuffer
   if image then image:draw(0, 0) end
 end
-
-return RoxyDialogue


### PR DESCRIPTION
### Overview
This release simplifies the `RoxyDialogue` module by removing an unnecessary return statement, aligning the module structure with the Playdate SDK’s recommended import behavior.

### Key Changes
- Removed `return RoxyDialogue` from `core/RoxyDialogue.lua`

### Challenges/Notes
- No behavior changes; all dialogue features continue to work as expected.